### PR TITLE
Add React Native workout tracker skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ProgressFit
+
+Minimal React Native workout tracker. Run `npm install` then `npm start` to launch.

--- a/data/routines.json
+++ b/data/routines.json
@@ -1,0 +1,31 @@
+{
+  "principiante_fuerza_completo": {
+    "name": "Rutina de Fuerza - Principiante (Gimnasio Completo)",
+    "description": "Rutina basica para empezar a construir fuerza.",
+    "days": [
+      {
+        "day": "Lunes",
+        "exercises": [
+          {
+            "id": "ej001",
+            "name": "Sentadilla con Barra",
+            "sets": 3,
+            "reps": "8-12",
+            "videoUrl": "https://example.com/videos/sentadilla.mp4",
+            "alternatives": [
+              {"id": "alt001", "name": "Sentadilla Goblet"}
+            ]
+          },
+          {
+            "id": "ej002",
+            "name": "Press de Banca con Barra",
+            "sets": 3,
+            "reps": "8-12",
+            "videoUrl": "https://example.com/videos/press_banca.mp4",
+            "alternatives": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+"name": "progressfit",
+"version": "0.1.0",
+"private": true,
+"scripts": {
+"start": "expo start"
+},
+"dependencies": {
+"react": "18.2.0",
+"react-native": "0.72.4",
+"@react-native-async-storage/async-storage": "^1.20.1",
+"expo": "^49.0.0"
+}
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import {UserProvider} from './context/user-context'
+import WelcomeScreen from './screens/welcome-screen'
+import TrainingScreen from './screens/training-screen'
+
+export default function App () {
+return (
+<UserProvider>
+<WelcomeScreen />
+<TrainingScreen />
+</UserProvider>
+)
+}

--- a/src/components/rest-timer.tsx
+++ b/src/components/rest-timer.tsx
@@ -1,0 +1,21 @@
+import React, {useEffect, useState} from 'react'
+import {Text} from 'react-native'
+
+export default function RestTimer ({duration}: {duration: number}) {
+const [timeLeft, setTimeLeft] = useState(duration)
+
+useEffect(() => {
+const id = setInterval(() => {
+setTimeLeft(t => {
+if (t <= 1) {
+clearInterval(id)
+return 0
+}
+return t - 1
+})
+}, 1000)
+return () => clearInterval(id)
+}, [duration])
+
+return <Text>Descanso: {timeLeft}s</Text>
+}

--- a/src/context/user-context.tsx
+++ b/src/context/user-context.tsx
@@ -1,0 +1,80 @@
+import React, {createContext, useState, useEffect} from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import routines from '../../data/routines.json'
+
+interface Preference {
+experience: string
+goal: string
+gymType: string
+}
+
+interface ExerciseProgress {
+weight: number
+reps: number
+}
+
+interface ProgressRecord {
+[exerciseId: string]: ExerciseProgress[]
+}
+
+interface UserContextProps {
+preferences: Preference | null
+routine: any | null
+progress: ProgressRecord
+setPreferences: (p: Preference) => void
+recordSet: (exerciseId: string, setData: ExerciseProgress) => void
+}
+
+export const UserContext = createContext<UserContextProps | undefined>(undefined)
+
+export function UserProvider ({children}: {children: React.ReactNode}) {
+const [preferences, setPreferencesState] = useState<Preference | null>(null)
+const [routine, setRoutine] = useState<any | null>(null)
+const [progress, setProgress] = useState<ProgressRecord>({})
+
+useEffect(() => {
+async function loadData () {
+const prefString = await AsyncStorage.getItem('preferences')
+if (prefString) {
+const pref: Preference = JSON.parse(prefString)
+setPreferencesState(pref)
+loadRoutine(pref)
+}
+const progString = await AsyncStorage.getItem('progress')
+if (progString) {
+setProgress(JSON.parse(progString))
+}
+}
+loadData()
+}, [])
+
+function setPreferences (p: Preference) {
+setPreferencesState(p)
+AsyncStorage.setItem('preferences', JSON.stringify(p))
+loadRoutine(p)
+}
+
+function loadRoutine (p: Preference) {
+const key = `${p.experience}_${p.goal}_${p.gymType}`
+// @ts-ignore
+const selected = (routines as any)[key]
+setRoutine(selected)
+}
+
+function recordSet (exerciseId: string, setData: ExerciseProgress) {
+setProgress(prev => {
+const exerciseSets = prev[exerciseId] || []
+const updated = {...prev, [exerciseId]: [...exerciseSets, setData]}
+AsyncStorage.setItem('progress', JSON.stringify(updated))
+return updated
+})
+}
+
+return (
+<UserContext.Provider
+value={{preferences, routine, progress, setPreferences, recordSet}}
+>
+{children}
+</UserContext.Provider>
+)
+}

--- a/src/screens/training-screen.tsx
+++ b/src/screens/training-screen.tsx
@@ -1,0 +1,56 @@
+import React, {useContext, useState} from 'react'
+import {View, Text, Button, TextInput, FlatList} from 'react-native'
+import {UserContext} from '../context/user-context'
+import RestTimer from '../components/rest-timer'
+
+export default function TrainingScreen () {
+const user = useContext(UserContext)
+const [currentSet, setCurrentSet] = useState(0)
+const [weight, setWeight] = useState('')
+const [reps, setReps] = useState('')
+
+if (!user || !user.routine) return null
+
+const exercises = user.routine.days[0].exercises
+const exercise = exercises[0]
+
+function handleCompleteSet () {
+user.recordSet(exercise.id, {
+weight: parseFloat(weight),
+reps: parseInt(reps, 10),
+})
+setCurrentSet(currentSet + 1)
+setWeight('')
+setReps('')
+}
+
+return (
+<View>
+<Text>{exercise.name}</Text>
+<Text>Serie {currentSet + 1} de {exercise.sets}</Text>
+<TextInput
+placeholder='Peso'
+keyboardType='numeric'
+value={weight}
+onChangeText={setWeight}
+/>
+<TextInput
+placeholder='Reps'
+keyboardType='numeric'
+value={reps}
+onChangeText={setReps}
+/>
+<Button title='Completar serie' onPress={handleCompleteSet} />
+<RestTimer key={currentSet} duration={60} />
+<FlatList
+data={user.progress[exercise.id]}
+keyExtractor={(_, i) => i.toString()}
+renderItem={({item}) => (
+<Text>
+{item.weight}kg x {item.reps}
+</Text>
+)}
+/>
+</View>
+)
+}

--- a/src/screens/welcome-screen.tsx
+++ b/src/screens/welcome-screen.tsx
@@ -1,0 +1,34 @@
+import React, {useState, useContext} from 'react'
+import {View, Text, Button, TextInput} from 'react-native'
+import {UserContext} from '../context/user-context'
+
+export default function WelcomeScreen () {
+const user = useContext(UserContext)
+const [experience, setExperience] = useState('principiante')
+const [goal, setGoal] = useState('fuerza')
+const [gymType, setGymType] = useState('completo')
+
+if (!user) return null
+
+function handleStart () {
+user.setPreferences({experience, goal, gymType})
+}
+
+return (
+<View>
+<Text>Bienvenido</Text>
+<TextInput
+placeholder='Experiencia'
+value={experience}
+onChangeText={setExperience}
+/>
+<TextInput placeholder='Objetivo' value={goal} onChangeText={setGoal} />
+<TextInput
+placeholder='Tipo de gimnasio'
+value={gymType}
+onChangeText={setGymType}
+/>
+<Button title='Iniciar' onPress={handleStart} />
+</View>
+)
+}


### PR DESCRIPTION
## Summary
- scaffold React Native project with package.json
- add context for user preferences and progress
- add onboarding and training screens
- add rest timer component
- include sample routine data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ab24dbc108324947e41b2d4d57dae